### PR TITLE
Upgrade path to React 16.3 and up

### DIFF
--- a/src/components/pages/index.js
+++ b/src/components/pages/index.js
@@ -100,7 +100,7 @@ export default class Pages extends PureComponent {
     this.mounted = false;
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     let { progress } = props;
 
     if (progress !== this.props.progress) {


### PR DESCRIPTION
Pushing support for React v16.3 and React-Native v0.54 and up by replacing componentWillReceiveProps with UNSAFE_componentWillReceiveProps.
 I apologize I didn't have the time to test it on the latest versions i.e React v16.3 and React Native v0.54. Please feel free to test it at your convenience and if it doesn't break anything merge with master. Thanks!